### PR TITLE
added --profile option to choose which device profile we use. 

### DIFF
--- a/gplaydl/auth.py
+++ b/gplaydl/auth.py
@@ -10,7 +10,7 @@ from typing import Optional
 import httpx
 from rich.console import Console
 
-from gplaydl.profiles import FALLBACK_PROFILE, get_priority_profiles
+from gplaydl.profiles import FALLBACK_PROFILE, get_priority_profiles, load_profile_from_path
 
 DEFAULT_DISPENSER_URL = "https://auroraoss.com/api/auth"
 
@@ -53,21 +53,27 @@ def clear_auth() -> None:
 def fetch_token(
     dispenser_url: Optional[str] = None,
     arch: str = "arm64",
+    profile_path: Optional[str] = None,
 ) -> Optional[dict]:
     """Obtain an anonymous auth token from the dispenser.
 
-    Rotates through device profiles until one yields an authToken.
+    When *profile_path* is provided, uses that single .properties file and
+    fails fast if it is rejected.  Otherwise rotates through built-in profiles
+    until one yields an authToken.
     Returns the full auth dict on success, None on failure.
     """
     url = dispenser_url or DEFAULT_DISPENSER_URL
     headers = {
-        "User-Agent": "com.aurora.store-4.6.1-70",
-        "Content-Type": "application/json",
-    }
+         "User-Agent": "com.aurora.store-4.6.1-70",
+         "Content-Type": "application/json",
+     }
 
-    profiles = get_priority_profiles(arch)
-    if not profiles:
-        profiles = [("fallback", FALLBACK_PROFILE)]
+    if profile_path is not None:
+        profiles = [("custom", load_profile_from_path(profile_path))]
+    else:
+        profiles = get_priority_profiles(arch)
+        if not profiles:
+            profiles = [("fallback", FALLBACK_PROFILE)]
 
     for profile_name, profile in profiles:
         device = profile.get("UserReadableName", profile_name)
@@ -90,6 +96,7 @@ _MAX_TOKEN_AGE = 50 * 60  # 50 minutes — refresh before the ~1h Google expiry
 def ensure_auth(
     arch: str = "arm64",
     dispenser_url: Optional[str] = None,
+    profile_path: Optional[str] = None,
     force_refresh: bool = False,
 ) -> Optional[dict]:
     """Return cached auth or fetch a new token transparently.
@@ -107,7 +114,7 @@ def ensure_auth(
     else:
         console.print("[dim]Refreshing token...[/dim]")
 
-    data = fetch_token(dispenser_url=dispenser_url, arch=arch)
+    data = fetch_token(dispenser_url=dispenser_url, arch=arch, profile_path=profile_path)
     if data:
         save_auth(data, arch)
     return data

--- a/gplaydl/cli.py
+++ b/gplaydl/cli.py
@@ -64,6 +64,7 @@ def main(
 def auth(
     arch: str = typer.Option("arm64", help="Architecture: arm64 or armv7."),
     dispenser: Optional[str] = typer.Option(None, "--dispenser", "-d", help="Custom dispenser URL."),
+    profile_path: Optional[str] = typer.Option(None, "--profile", "-p", help="Path to a device .properties file."),
     clear: bool = typer.Option(False, "--clear", help="Remove all cached tokens."),
 ) -> None:
     """Acquire an anonymous auth token from the dispenser."""
@@ -77,7 +78,11 @@ def auth(
     rprint()
 
     with console.status("Rotating through device profiles..."):
-        data = fetch_token(dispenser_url=dispenser, arch=arch)
+        try:
+            data = fetch_token(dispenser_url=dispenser, arch=arch, profile_path=profile_path)
+        except FileNotFoundError as exc:
+            err.print(f"[red]{exc}[/red]")
+            raise typer.Exit(code=1)
 
     if not data:
         err.print("[red]Authentication failed — all profiles rejected.[/red]")
@@ -101,16 +106,17 @@ def info(
     package: str = typer.Argument(..., help="Package name (e.g. com.whatsapp)."),
     arch: str = typer.Option("arm64", help="Architecture for token."),
     dispenser: Optional[str] = typer.Option(None, "--dispenser", "-d", help="Custom dispenser URL."),
+    profile_path: Optional[str] = typer.Option(None, "--profile", "-p", help="Path to a device .properties file."),
 ) -> None:
     """Show app details from Google Play."""
-    auth_data = _require_auth(arch, dispenser)
+    auth_data = _require_auth(arch, dispenser, profile_path)
 
     with console.status(f"Fetching details for [bold]{package}[/bold]..."):
         try:
             try:
                 details = get_details(package, auth_data)
             except AuthExpiredError:
-                auth_data = _require_auth(arch, dispenser, force=True)
+                auth_data = _require_auth(arch, dispenser, profile_path, force=True)
                 details = get_details(package, auth_data)
         except PlayAPIError as exc:
             err.print(f"[red]{exc}[/red]")
@@ -137,16 +143,17 @@ def search(
     limit: int = typer.Option(10, "--limit", "-l", help="Max results."),
     arch: str = typer.Option("arm64", help="Architecture for token."),
     dispenser: Optional[str] = typer.Option(None, "--dispenser", "-d", help="Custom dispenser URL."),
+    profile_path: Optional[str] = typer.Option(None, "--profile", "-p", help="Path to a device .properties file."),
 ) -> None:
     """Search for apps on Google Play."""
-    auth_data = _require_auth(arch, dispenser)
+    auth_data = _require_auth(arch, dispenser, profile_path)
 
     with console.status(f"Searching for [bold]{query}[/bold]..."):
         try:
             try:
                 results = search_apps(query, auth_data, limit=limit)
             except AuthExpiredError:
-                auth_data = _require_auth(arch, dispenser, force=True)
+                auth_data = _require_auth(arch, dispenser, profile_path, force=True)
                 results = search_apps(query, auth_data, limit=limit)
         except PlayAPIError as exc:
             err.print(f"[red]{exc}[/red]")
@@ -173,16 +180,17 @@ def list_splits_cmd(
     package: str = typer.Argument(..., help="Package name."),
     arch: str = typer.Option("arm64", help="Architecture for token."),
     dispenser: Optional[str] = typer.Option(None, "--dispenser", "-d", help="Custom dispenser URL."),
+    profile_path: Optional[str] = typer.Option(None, "--profile", "-p", help="Path to a device .properties file."),
 ) -> None:
     """List available split APKs for an app."""
-    auth_data = _require_auth(arch, dispenser)
+    auth_data = _require_auth(arch, dispenser, profile_path)
 
     with console.status(f"Fetching splits for [bold]{package}[/bold]..."):
         try:
             try:
                 splits = api_list_splits(package, auth_data)
             except AuthExpiredError:
-                auth_data = _require_auth(arch, dispenser, force=True)
+                auth_data = _require_auth(arch, dispenser, profile_path, force=True)
                 splits = api_list_splits(package, auth_data)
         except PlayAPIError as exc:
             err.print(f"[red]{exc}[/red]")
@@ -211,11 +219,12 @@ def download(
     arch: str = typer.Option("arm64", "--arch", "-a", help="Architecture: arm64 or armv7."),
     version: Optional[int] = typer.Option(None, "--version", "-v", help="Specific version code."),
     dispenser: Optional[str] = typer.Option(None, "--dispenser", "-d", help="Custom dispenser URL."),
+    profile_path: Optional[str] = typer.Option(None, "--profile", "-p", help="Path to a device .properties file."),
     no_splits: bool = typer.Option(False, "--no-splits", help="Skip downloading split APKs."),
     no_extras: bool = typer.Option(False, "--no-extras", help="Skip downloading additional files (OBB, asset packs)."),
 ) -> None:
     """Download an APK (with splits + additional files) from Google Play."""
-    auth_data = _require_auth(arch, dispenser)
+    auth_data = _require_auth(arch, dispenser, profile_path)
     output.mkdir(parents=True, exist_ok=True)
 
     # ── details + purchase + delivery (with auto-retry on expired token) ─
@@ -228,7 +237,7 @@ def download(
                 purchase(package, vc, auth_data)
                 delivery = get_delivery(package, vc, auth_data)
         except AuthExpiredError:
-            auth_data = _require_auth(arch, dispenser, force=True)
+            auth_data = _require_auth(arch, dispenser, profile_path, force=True)
             with console.status(f"Fetching details for [bold]{package}[/bold]..."):
                 details = get_details(package, auth_data)
             vc = version or details.version_code
@@ -315,9 +324,9 @@ def download(
 # ── helpers ─────────────────────────────────────────────────────────────────
 
 
-def _require_auth(arch: str, dispenser: Optional[str], *, force: bool = False) -> dict:
+def _require_auth(arch: str, dispenser: Optional[str], profile_path: Optional[str] = None, *, force: bool = False) -> dict:
     """Return auth dict or exit with a helpful error."""
-    data = ensure_auth(arch=arch, dispenser_url=dispenser, force_refresh=force)
+    data = ensure_auth(arch=arch, dispenser_url=dispenser, profile_path=profile_path, force_refresh=force)
     if not data:
         err.print(
             "[red]Could not obtain an auth token. "

--- a/gplaydl/profiles.py
+++ b/gplaydl/profiles.py
@@ -155,3 +155,19 @@ def get_priority_profiles(arch: str = "arm64") -> list[tuple[str, dict]]:
             seen.add(pkey)
 
     return result
+
+
+
+def load_profile_from_path(path: str) -> dict:
+    """Load a single device profile from a .properties file path.
+
+    Returns the raw profile dict (same shape as the ``"profile"`` value in
+        :data:`_ALL`), auto-detecting architecture from the ``Platforms`` field.
+    Raises ``FileNotFoundError`` if the file does not exist.
+    """
+    filepath = Path(path)
+    if not filepath.exists():
+        raise FileNotFoundError(f"Profile file not found: {filepath}")
+
+    profile = _load_properties(filepath)
+    return profile

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,7 @@ Download APKs from Google Play Store using anonymous authentication. Downloads b
 
 - Anonymous authentication via Aurora Store's token dispenser (no Google account needed)
 - 23 device profiles with automatic rotation for reliable token acquisition
+- Select a specific device profile by path (`--profile`) for reproducible authentication
 - Downloads base APK, split APKs, OBB files, and asset packs in one go
 - Streaming gzip decompression for Play Asset Delivery packs
 - Beautiful terminal UI with real-time download progress bars
@@ -48,7 +49,8 @@ gplaydl download com.whatsapp
 ```bash
 gplaydl auth                          # Default (arm64)
 gplaydl auth --arch armv7             # Token for older ARM devices
-gplaydl auth -d https://my-server/api # Use a custom dispenser
+gplaydl auth -d https://my-server/api    # Use a custom dispenser
+gplaydl auth --profile profiles/D2.properties    # Use a specific device profile
 gplaydl auth --clear                  # Remove all cached tokens
 ```
 
@@ -65,6 +67,7 @@ gplaydl download com.whatsapp -a armv7          # ARMv7 build
 gplaydl download com.whatsapp -v 231205015      # Specific version code
 gplaydl download com.whatsapp --no-splits       # Skip split APKs
 gplaydl download com.whatsapp --no-extras       # Skip OBB / asset packs
+gplaydl download com.whatsapp --profile profiles/D2.properties     # Use specific device profile
 gplaydl download com.whatsapp -d https://...    # Use custom dispenser
 ```
 
@@ -135,6 +138,13 @@ gplaydl download com.whatsapp -d https://my-dispenser.example.com/api/auth
 ## Device Profiles
 
 The tool includes 23 device profiles from Aurora Store, used to authenticate with Google Play's token dispenser. Profiles are rotated automatically during token acquisition to maximize compatibility.
+
+You can select a specific profile by path using `--profile` / `-p` for reproducible authentication:
+
+```bash
+gplaydl auth --profile gplaydl/profiles/D2.properties
+gplaydl download com.whatsapp --profile gplaydl/profiles/Pv.properties
+```
 
 Profiles are stored as `.properties` files in the `gplaydl/profiles/` directory.
 


### PR DESCRIPTION
Greeting,
First thanks for this project
So I added argument `--profile` to download OEM specific package e.g: `com.samsung.android.knox.kpu`
e.g: 
```bash
python -m gplaydl auth --profile gplaydl/profiles/D2.properties
python -m gplaydl download com.samsung.android.knox.kpu --profile gplaydl/profiles/D2.properties
```